### PR TITLE
make natural-compare.js module work in phantomjs and browser

### DIFF
--- a/natural-compare.js
+++ b/natural-compare.js
@@ -113,4 +113,11 @@ Object.defineProperties(naturalCompare, {
   },
 });
 
-module.exports = naturalCompare;
+// trick taken from https://gist.github.com/drmikecrowe/4bf0938ea73bf704790f
+(function(window) {
+  if (typeof module === 'object' && module && typeof module.exports === 'object') {
+    module.exports = naturalCompare;
+  } else {
+    window.naturalCompare = naturalCompare;
+  }
+})(this);


### PR DESCRIPTION
Typical problem with current compare library is that module is not defined for all javascript environments. So that

> karma start .config/karma.conf.js --single-run


START:
11 07 2018 10:21:17.008:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
11 07 2018 10:21:17.009:INFO [launcher]: Launching browser PhantomJS with concurrency 1
11 07 2018 10:21:17.013:INFO [launcher]: Starting browser PhantomJS
11 07 2018 10:21:17.342:INFO [PhantomJS 2.1.1 (Linux 0.0.0)]: Connected on socket 9ROWeFHnestrLBQMAAAA with id 59041371
PhantomJS 2.1.1 (Linux 0.0.0) ERROR
  ReferenceError: Can't find variable: module
  at ui/lib/lib.js:3729

Finished in 0.13 secs / 0 secs

SUMMARY:
✔ 0 tests completed

I have used code from  https://gist.github.com/drmikecrowe/4bf0938ea73bf704790f to work around that issue.
