### PR TITLE
Fix: Sort out-of-alphabet characters last

### DIFF
--- a/natural-compare.js
+++ b/natural-compare.js
@@ -84,10 +84,8 @@ function naturalCompare(a, b, opts) {
 
     if (charCodeA !== charCodeB) {
       if (
-        charCodeA < alphabetIndexMap.length &&
-        charCodeB < alphabetIndexMap.length &&
-        alphabetIndexMap[charCodeA] !== -1 &&
-        alphabetIndexMap[charCodeB] !== -1
+        alphabetIndexMap[charCodeA] !== undefined &&
+        alphabetIndexMap[charCodeB] !== undefined
       ) {
         return alphabetIndexMap[charCodeA] - alphabetIndexMap[charCodeB];
       }
@@ -119,14 +117,6 @@ function buildAlphabetIndexMap(alphabet) {
   }
 
   const indexMap = [];
-  const maxCharCode = alphabet.split('').reduce((maxCode, char) => {
-    return Math.max(maxCode, char.charCodeAt(0));
-  }, 0);
-
-  for (let i = 0; i <= maxCharCode; i++) {
-    indexMap.push(-1);
-  }
-
   for (let i = 0; i < alphabet.length; i++) {
     indexMap[alphabet.charCodeAt(i)] = i;
   }

--- a/natural-compare.js
+++ b/natural-compare.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const defaultAlphabetIndexMap = [];
+defaultAlphabetIndexMap.maxCode = 0;
 
 function isNumberCode(code) {
   return code >= 48/* '0' */ && code <= 57/* '9' */;
@@ -82,15 +83,17 @@ function naturalCompare(a, b, opts) {
       continue;
     }
 
-    if (charCodeA !== charCodeB) {
-      if (
-        alphabetIndexMap[charCodeA] !== undefined &&
-        alphabetIndexMap[charCodeB] !== undefined
-      ) {
-        return alphabetIndexMap[charCodeA] - alphabetIndexMap[charCodeB];
-      }
+    let resolvedCodeA = alphabetIndexMap[charCodeA];
+    if (resolvedCodeA === undefined) {
+      resolvedCodeA = charCodeA + alphabetIndexMap.maxCode;
+    }
+    let resolvedCodeB = alphabetIndexMap[charCodeB];
+    if (resolvedCodeB === undefined) {
+      resolvedCodeB = charCodeB + alphabetIndexMap.maxCode;
+    }
 
-      return charCodeA - charCodeB;
+    if (resolvedCodeA !== resolvedCodeB) {
+      return resolvedCodeA - resolvedCodeB;
     }
 
     ++indexA;
@@ -117,8 +120,14 @@ function buildAlphabetIndexMap(alphabet) {
   }
 
   const indexMap = [];
+  indexMap.maxCode = 0;
+
   for (let i = 0; i < alphabet.length; i++) {
-    indexMap[alphabet.charCodeAt(i)] = i;
+    const code = alphabet.charCodeAt(i);
+    indexMap[code] = i;
+    if (code > indexMap.maxCode) {
+      indexMap.maxCode = code;
+    }
   }
 
   alphabetIndexMapCache[alphabet] = indexMap;

--- a/test/test.js
+++ b/test/test.js
@@ -261,6 +261,13 @@ describe('naturalCompare()', () => {
     naturalCompare.alphabet = null; // Reset alphabet for other tests
   });
 
+  it('should sort letters outside of provided alphabet last', () => {
+    const opts = {
+      alphabet: 'AÁBCDÐEÉFGHIÍJKLMNOÓPQRSTUÚVWXYÝZÞÆÖaábcdðeéfghiíjklmnoópqrstuúvwxyýzþæö',
+    };
+    ['ä', 'ö'].sort((a, b) => naturalCompare(a, b, opts)).should.deepEqual(['ö', 'ä']);
+  });
+
 
   describe('with {caseInsensitive: true}', () => {
 


### PR DESCRIPTION
Hi. This PR makes the handling of out-of-alphabet characters (this regularly happens in real world data) predictable by sorting them last.

In the current version they have a tendency of appearing somewhere in the middle of the supplied alphabet.
